### PR TITLE
Fix resetSlider recalculation bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -1370,7 +1370,8 @@
                     const labelId = slider.id + 'Label';
                     updateSliderLabel(slider, labelId, slider.id === 'initialCapital' || slider.id === 'monthlyContribution' ? '$' : '');
                 }
-                recalculate();
+                recalculateWithoutChart();
+                updateAllocationChart();
             }
         }
 


### PR DESCRIPTION
## Summary
- fix `resetSlider` function to use existing `recalculateWithoutChart()` and refresh chart

## Testing
- `grep -n "recalculate();" -R || echo 'none'`

------
https://chatgpt.com/codex/tasks/task_b_6841e39886b4832bb58c1e49661373fb